### PR TITLE
#3 .gitignore Gitで管理しなくてよいファイルを除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,26 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Python キャッシュファイルを無視
+__pycache__/
+*.py[cod]
+*.so
+
+# 仮想環境を無視
+venv/
+ENV/
+.venv/
+
+# 環境変数ファイル（機密情報）
+.env
+*.env
+
+# npm install で生成されるファイル
+node_modules/
+
+# React のキャッシュファイル
+.cache/
+.next/  # Next.js を使う場合
+build/
+dist/


### PR DESCRIPTION
## 🔹 変更内容
- `.gitignore` を作成し、不要なファイルが Git に含まれないように設定
- 除外対象:
  - `__pycache__/`（Python のキャッシュファイル）
  - `venv/`（Python 仮想環境）
  - `node_modules/`（フロントエンドの依存ファイル）
  - `.env`（環境変数ファイル）

## 🔹 目的
- Git に不要なファイルを含めないことでリポジトリをクリーンに保つ
- 機密情報（`.env`）が誤ってプッシュされるのを防ぐ

## 🔹Docker を使用するべきか？

- 結論： 現時点では Docker を使用しなくてもOK！ 
- しかし、将来的に環境を統一したい場合は導入を検討する価値があります。

## 🔹 Docker を使用しなくてもいい理由

- Lambda はサーバーレスなので、Docker がなくても AWS 上で動作する
- ローカル環境（Mac / Windows / Linux）で Python を直接動かせる
- 必要な Python ライブラリを requirements.txt で管理すれば、どこでも同じ環境を構築できる
- React も npx create-react-app frontend で簡単にセットアップ可能
- AWS 上にデプロイするなら Docker なしでも動作する

## 🔹 Docker を使うべきケース

- ローカル環境と AWS 環境を完全に統一したい
- Lambda を Docker コンテナとしてデプロイしたい
- チーム開発で、全員の環境を同じにしたい
