### PR TITLE
#5/2.1 Python 3.x のインストール

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,38 @@ DynamoDB は **NoSQLデータベース** なので、データはそのまま JS
 | **フロントエンド** | React を使用し、S3 に静的ファイルを配置し、CloudFront で配信 |
 | **バックエンド** | AWS Lambda（Python）を API Gateway 経由で呼び出す |
 | **データベース** | RDS（MySQL）はリレーショナルデータとして保存、DynamoDB は JSON のまま保存 |
+
+
+# Python 環境構築（Windows 11）
+
+## 1️⃣ Python のインストール手順（Windows 11）
+
+### ✅ 正しい Python のダウンロード
+1. [Python 公式サイト](https://www.python.org/downloads/windows/) にアクセス
+2. 「Looking for a specific release?」のセクションから最新の安定版を選択
+3. **「Windows installer (64-bit)」** をダウンロード  
+   ✅ `python-3.x.x-amd64.exe` を選ぶ（Microsoft Store 版ではない）
+
+### ✅ インストール手順
+1. **ダウンロードしたインストーラーを実行**
+2. **「Add Python to PATH」にチェックを入れる**
+3. **「Install Now」をクリック**
+4. **インストール完了後、「Disable path length limit」をクリック**
+5. **PC を再起動**
+
+---
+
+## 2️⃣ インストール後の確認と Microsoft Store の影響チェック
+
+### ✅ Python の動作確認
+```bash
+python --version
+python3 --version
+pip --version
+
+**成功表示**
+Python 3.13.2
+Python 3.13.2
+pip 24.3.1 from C:\Program Files\Python313\Lib\site-packages\pip (python 3.13)
+```
+


### PR DESCRIPTION
## issue
- closes  #5

## 📝 概要
この PR では、Windows 11 環境で **Python 3.x のインストール** を正しく適用するための手順をまとめ、環境を構築しました。

## 🔧 実施内容
- **Python 3.x を公式サイトからダウンロード & インストール**
- **Microsoft Store 版の影響を回避**
- **環境変数（PATH）の設定**
- **Python / pip のバージョン確認**
- **仮想環境（venv）の作成・有効化**
- **README.md への手順追記**

---

## 📌 インストール手順（Windows 11）
### ✅ **Python の公式インストール**
1. [Python 公式サイト](https://www.python.org/downloads/windows/) にアクセス
2. 「Looking for a specific release?」から最新の **Python 3.x.x** を選択
3. **「Windows installer (64-bit)」をダウンロード**
   \`\`\`plaintext
   例: python-3.13.2-amd64.exe
   \`\`\`
4. **インストーラーを実行し、「Add Python to PATH」に✅チェックを入れてインストール**
5. **「Disable path length limit」をクリック**
6. **PC を再起動**

### ✅ **インストール確認**
\`\`\`bash
python --version
python3 --version
pip --version
\`\`\`
**期待する出力**
\`\`\`
Python 3.13.2
Python 3.13.2
pip 24.3.1 from C:\Program Files\Python313\Lib\site-packages\pip (python 3.13)
\`\`\`

---

## ⚠ **Microsoft Store 版の影響を防ぐ**
### **問題**
\`python --version\` の出力が \`"Python"\` だけになる場合、Microsoft Store 版の影響を受けている可能性がある。

### **対応手順**
\`\`\`bash
where python
where python3
\`\`\`
❌ \`C:\Users\okita\AppData\Local\Microsoft\WindowsApps\python.exe\` が出る場合：
1. **Windows設定 → 「アプリ」 → 「インストールされたアプリ」**
2. **Microsoft Store 版の Python をアンインストール**
3. **環境変数「Path」から \`C:\Users\okita\AppData\Local\Microsoft\WindowsApps\` を削除**
4. **PC を再起動し、再確認**
5. 必要なら `alias python3=python` を設定
   \`\`\`bash
   echo "alias python3=python" >> ~/.bashrc
   source ~/.bashrc
   \`\`\`

---

## 🏗 **仮想環境（venv）の作成**
### ✅ **仮想環境を作成**
\`\`\`bash
cd ~/projects/device-management/backend
python -m venv venv
\`\`\`

### ✅ **仮想環境を有効化**
\`\`\`bash
source venv/Scripts/activate  # GitBash の場合
# または PowerShell の場合
venv\Scripts\Activate.ps1
\`\`\`

### ✅ **動作確認**
\`\`\`bash
python --version
pip --version
\`\`\`
**成功すると `(venv)` が表示される**
\`\`\`
(venv) okita@tamaPC MINGW64 ~/projects/device-management/backend $
\`\`\`

### ✅ **仮想環境の無効化**
\`\`\`bash
deactivate
\`\`\`

---

## 🎯 **開発の流れ（まとめ）**
1. **プロジェクトディレクトリに移動**
   \`\`\`bash
   cd ~/projects/device-management/backend
   \`\`\`
2. **仮想環境を有効化**
   \`\`\`bash
   source venv/Scripts/activate
   \`\`\`
3. **Python の開発を開始**
   \`\`\`bash
   python main.py
   \`\`\`
4. **ライブラリの管理**
   \`\`\`bash
   pip install requests
   pip freeze > requirements.txt
   \`\`\`
5. **開発終了後、仮想環境を無効化**
   \`\`\`bash
   deactivate
   \`\`\`

---

## 📝 変更ファイル
- `README.md` に **Windows 11 向け Python インストール手順** を追記
- `venv/` フォルダを `.gitignore` に追加（Git 管理対象外）

---

## ✅ 動作確認
- [x] `python --version` で **Python 3.13.2** を確認
- [x] `pip --version` で **pip 24.3.1** を確認
- [x] 仮想環境の作成 & 有効化
- [x] Microsoft Store 版の影響がないことを確認
- [x] `.gitignore` に `venv/` を追加し、不要なファイルを Git に含めないように設定

---