### PR TITLE
#15/ 3.4 CloudFront ディストリビューションの設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,3 +641,159 @@ aws s3api list-buckets
 
 
 ---
+
+# 🚀 CloudFront を使用した S3 静的サイトホスティング
+
+## **1️⃣ CloudFront S3 Access Denied エラーの発生と解消手順**
+
+### **❌ エラー発生のタイミング**
+CloudFront を通じて S3 にホストした静的サイト (`index.html`) にアクセスした際に、**以下のエラーが発生しました。**
+
+```xml
+<Error>
+<Code>AccessDenied</Code>
+<Message>Access Denied</Message>
+<RequestId>Q8ZNTG61DHYVZY2R</RequestId>
+<HostId>fquG2agx//MMoGK8iN/96xH2RyBM1ITVwjwaAfH68pZpV1GaigsRs2Gtyyo8ByHPwkahB+rMmGaOnHyP5kvQV7Y5ezcIiSzJqwKwocf30cs=</HostId>
+</Error>
+```
+
+**このエラーの原因**
+1. **CloudFront のオリジン設定が誤っていた**
+   - `distribution-config.json` の `"Origins.DomainName"` が `d1zw3p63uw42m7.cloudfront.net` になっており、本来指定すべき `device-mgmt-frontend-bucket.s3.amazonaws.com` になっていなかった。
+
+2. **S3 バケットが CloudFront からのアクセスを許可していなかった**
+   - S3 バケットポリシーが CloudFront からの `s3:GetObject` を許可していなかった。
+
+3. **S3 のパブリックアクセス設定が適切でなかった**
+   - `"BlockPublicPolicy": true` になっており、CloudFront 経由のリクエストもブロックされていた。
+
+4. **CloudFront のキャッシュが古い設定を保持していた**
+   - 設定を変更しても、CloudFront に古いバージョンがキャッシュされており、更新が適用されていなかった。
+
+---
+
+## **2️⃣ CloudFront S3 Access Denied エラーの解決手順**
+
+### **1. Origin Access Control (OAC) の作成**
+```bash
+aws cloudfront create-origin-access-control \
+    --origin-access-control-config '{
+        "Name": "device-mgmt-frontend-OAC",
+        "Description": "OAC for frontend",
+        "SigningBehavior": "always",
+        "SigningProtocol": "sigv4",
+        "OriginAccessControlOriginType": "s3"
+    }'
+```
+
+✅ **作成された OAC の ID (`E1JCQCLG0RPNWU`) を取得し、CloudFront に適用。**
+
+---
+
+### **2. CloudFront のオリジン設定を OAC に更新**
+#### **📌 `distribution-config.json` 修正**
+```json
+"Origins": {
+    "Items": [
+        {
+            "Id": "device-mgmt-frontend-bucket",
+            "DomainName": "device-mgmt-frontend-bucket.s3.amazonaws.com",
+            "OriginAccessControlId": "E1JCQCLG0RPNWU"
+        }
+    ]
+}
+```
+
+✅ **CloudFront の設定を適用**
+```bash
+aws cloudfront update-distribution --id E1OJBU6FBKY6X --if-match $(aws cloudfront get-distribution --id E1OJBU6FBKY6X --query "ETag" --output text) --distribution-config file://distribution-config.json
+```
+
+---
+
+### **3. S3 バケットポリシーを更新**
+#### **📌 `bucket-policy.json`**
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowCloudFrontServicePrincipal",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "cloudfront.amazonaws.com"
+            },
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::device-mgmt-frontend-bucket/*",
+            "Condition": {
+                "StringEquals": {
+                    "AWS:SourceArn": "arn:aws:cloudfront::881490109259:distribution/E1OJBU6FBKY6X"
+                }
+            }
+        }
+    ]
+}
+```
+
+✅ **バケットポリシーを適用**
+```bash
+aws s3api put-bucket-policy --bucket device-mgmt-frontend-bucket --policy file://bucket-policy.json
+```
+
+---
+
+### **4. S3 のパブリックアクセス設定を修正**
+```bash
+aws s3api put-public-access-block \
+    --bucket device-mgmt-frontend-bucket \
+    --public-access-block-configuration '{
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true,
+        "BlockPublicPolicy": false,
+        "RestrictPublicBuckets": false
+    }'
+```
+
+---
+
+### **5. テストファイルのアップロードとキャッシュ無効化**
+CloudFront の設定変更が正しく適用されているかを確認するため、**テスト用の `index.html` をアップロード** し、**キャッシュを無効化** しました。
+
+```bash
+# テスト用 HTML ファイルを作成
+echo "<html><body><h1>Hello from S3 via CloudFront</h1></body></html>" > index.html
+
+# S3 にアップロード
+aws s3 cp index.html s3://device-mgmt-frontend-bucket/
+
+# CloudFront のキャッシュを無効化
+aws cloudfront create-invalidation --distribution-id E1OJBU6FBKY6X --paths "/*"
+```
+
+✅ **S3 にファイルをアップロードし、キャッシュをクリアすることで最新の変更が反映される**
+
+---
+
+### **6. 動作確認**
+```bash
+https://d1zw3p63uw42m7.cloudfront.net/index.html
+```
+✅ **"Hello from S3 via CloudFront" が表示されれば成功 🎉**
+
+---
+
+## **3️⃣ 重要なポイント**
+1. **OAC の作成と正しい ID の設定**
+2. **CloudFront 設定での OAC ID の正確な反映**
+3. **S3 バケットポリシーでの CloudFront サービスプリンシパルの許可**
+4. **パブリックアクセスブロック設定の適切な構成**
+5. **キャッシュ無効化による変更の反映**
+6. **テスト用ファイルのアップロードと CloudFront 経由でのアクセス確認**
+
+---
+
+## **4️⃣ まとめ**
+この手順により、S3 を **パブリックにせず、CloudFront 経由でのみアクセスできる構成** が完成しました。
+
+---

--- a/frontend/bucket-policy.json
+++ b/frontend/bucket-policy.json
@@ -1,0 +1,19 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowCloudFrontServicePrincipal",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "cloudfront.amazonaws.com"
+            },
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::device-mgmt-frontend-bucket/*",
+            "Condition": {
+                "StringEquals": {
+                    "AWS:SourceArn": "arn:aws:cloudfront::881490109259:distribution/E1OJBU6FBKY6X"
+                }
+            }
+        }
+    ]
+}

--- a/frontend/cors.json
+++ b/frontend/cors.json
@@ -1,0 +1,9 @@
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["*"],
+      "AllowedMethods": ["GET", "HEAD"],
+      "AllowedHeaders": ["*"]
+    }
+  ]
+}

--- a/frontend/distribution-config.json
+++ b/frontend/distribution-config.json
@@ -1,0 +1,117 @@
+{
+    "CallerReference": "cli-1739882289-217072",
+    "Aliases": {
+        "Quantity": 0
+    },
+    "DefaultRootObject": "index.html",
+    "Origins": {
+        "Quantity": 1,
+        "Items": [
+            {
+                "Id": "device-mgmt-frontend-bucket",
+                "DomainName": "device-mgmt-frontend-bucket.s3.amazonaws.com",
+                "OriginPath": "",
+                "CustomHeaders": {
+                    "Quantity": 0
+                },
+                "S3OriginConfig": {
+                    "OriginAccessIdentity": ""
+                },
+                "ConnectionAttempts": 3,
+                "ConnectionTimeout": 10,
+                "OriginShield": {
+                    "Enabled": false
+                },
+                "OriginAccessControlId": "E1JCQCLG0RPNWU"
+            }
+        ]
+    },
+    "OriginGroups": {
+        "Quantity": 0
+    },
+    "DefaultCacheBehavior": {
+        "TargetOriginId": "device-mgmt-frontend-bucket",
+        "TrustedSigners": {
+            "Enabled": false,
+            "Quantity": 0
+        },
+        "TrustedKeyGroups": {
+            "Enabled": false,
+            "Quantity": 0
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "AllowedMethods": {
+            "Quantity": 2,
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Quantity": 2,
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ]
+            }
+        },
+        "SmoothStreaming": false,
+        "Compress": false,
+        "LambdaFunctionAssociations": {
+            "Quantity": 0
+        },
+        "FunctionAssociations": {
+            "Quantity": 0
+        },
+        "FieldLevelEncryptionId": "",
+        "GrpcConfig": {
+            "Enabled": false
+        },
+        "ForwardedValues": {
+            "QueryString": false,
+            "Cookies": {
+                "Forward": "none"
+            },
+            "Headers": {
+                "Quantity": 0
+            },
+            "QueryStringCacheKeys": {
+                "Quantity": 0
+            }
+        },
+        "MinTTL": 0,
+        "DefaultTTL": 86400,
+        "MaxTTL": 31536000
+    },
+    "CacheBehaviors": {
+        "Quantity": 0
+    },
+    "CustomErrorResponses": {
+        "Quantity": 0
+    },
+    "Comment": "",
+    "Logging": {
+        "Enabled": false,
+        "IncludeCookies": false,
+        "Bucket": "",
+        "Prefix": ""
+    },
+    "PriceClass": "PriceClass_All",
+    "Enabled": true,
+    "ViewerCertificate": {
+        "CloudFrontDefaultCertificate": true,
+        "SSLSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CertificateSource": "cloudfront"
+    },
+    "Restrictions": {
+        "GeoRestriction": {
+            "RestrictionType": "none",
+            "Quantity": 0
+        }
+    },
+    "WebACLId": "",
+    "HttpVersion": "http2",
+    "IsIPV6Enabled": true,
+    "ContinuousDeploymentPolicyId": "",
+    "Staging": false
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,1 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
-</html>
+<html><body><h1>Hello from S3 via CloudFront</h1></body></html>


### PR DESCRIPTION
## issue
- closes  #15 

# 🚀 CloudFront S3 Access Denied エラーの修正と設定の適用

## **🔍 エラーの発生タイミング**
CloudFront を通じて S3 にホストした静的サイト (`index.html`) にアクセスした際に、以下の `AccessDenied` エラーが発生しました。

```xml
<Error>
<Code>AccessDenied</Code>
<Message>Access Denied</Message>
<RequestId>Q8ZNTG61DHYVZY2R</RequestId>
<HostId>fquG2agx//MMoGK8iN/96xH2RyBM1ITVwjwaAfH68pZpV1GaigsRs2Gtyyo8ByHPwkahB+rMmGaOnHyP5kvQV7Y5ezcIiSzJqwKwocf30cs=</HostId>
</Error>
```

**🛑 エラーの原因**
1. **CloudFront のオリジン設定 (`Origins.DomainName`) が `device-mgmt-frontend-bucket.s3.amazonaws.com` になっていなかった**
2. **S3 バケットが CloudFront からの `s3:GetObject` アクセスを許可していなかった**
3. **S3 のパブリックアクセス設定 (`BlockPublicPolicy`: true) により、CloudFront からのアクセスもブロックされていた**
4. **CloudFront のキャッシュが古い設定を保持していたため、変更が適用されていなかった**

---

## **🛠 エラー解消のための対応**

### **✅ 1. CloudFront の Origin Access Control (OAC) を作成**
CloudFront から S3 に直接アクセスできるよう **OAC (Origin Access Control)** を作成しました。

```bash
aws cloudfront create-origin-access-control \
    --origin-access-control-config '{
        "Name": "device-mgmt-frontend-OAC",
        "Description": "OAC for frontend",
        "SigningBehavior": "always",
        "SigningProtocol": "sigv4",
        "OriginAccessControlOriginType": "s3"
    }'
```

**🎯 作成された OAC の ID (`E1JCQCLG0RPNWU`) を取得し、CloudFront に適用。**

---

### **✅ 2. CloudFront のオリジン設定 (`distribution-config.json`) を修正**
CloudFront のオリジンを S3 に正しく設定し、OAC を適用しました。

```json
"Origins": {
    "Items": [
        {
            "Id": "device-mgmt-frontend-bucket",
            "DomainName": "device-mgmt-frontend-bucket.s3.amazonaws.com",
            "OriginAccessControlId": "E1JCQCLG0RPNWU"
        }
    ]
}
```

**🎯 修正後、CloudFront の設定を適用**
```bash
aws cloudfront update-distribution --id E1OJBU6FBKY6X --if-match $(aws cloudfront get-distribution --id E1OJBU6FBKY6X --query "ETag" --output text) --distribution-config file://distribution-config.json
```

---

### **✅ 3. S3 バケットポリシーを更新**
S3 バケットが CloudFront からのアクセスのみ許可するようにポリシーを変更しました。

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "AllowCloudFrontServicePrincipal",
            "Effect": "Allow",
            "Principal": {
                "Service": "cloudfront.amazonaws.com"
            },
            "Action": "s3:GetObject",
            "Resource": "arn:aws:s3:::device-mgmt-frontend-bucket/*",
            "Condition": {
                "StringEquals": {
                    "AWS:SourceArn": "arn:aws:cloudfront::881490109259:distribution/E1OJBU6FBKY6X"
                }
            }
        }
    ]
}
```

**🎯 バケットポリシーを適用**
```bash
aws s3api put-bucket-policy --bucket device-mgmt-frontend-bucket --policy file://bucket-policy.json
```

---

### **✅ 4. S3 のパブリックアクセス制限を適切に設定**
S3 を完全にパブリックにするのではなく、CloudFront からのアクセスのみ許可しました。

```bash
aws s3api put-public-access-block \
    --bucket device-mgmt-frontend-bucket \
    --public-access-block-configuration '{
        "BlockPublicAcls": true,
        "IgnorePublicAcls": true,
        "BlockPublicPolicy": false,
        "RestrictPublicBuckets": false
    }'
```

---

### **✅ 5. テストファイルのアップロードとキャッシュ無効化**
変更が正しく適用されているか確認するため、テスト用の `index.html` をアップロードし、CloudFront のキャッシュをクリアしました。

```bash
# テスト用 HTML ファイルを作成
echo "<html><body><h1>Hello from S3 via CloudFront</h1></body></html>" > index.html

# S3 にアップロード
aws s3 cp index.html s3://device-mgmt-frontend-bucket/

# CloudFront のキャッシュを無効化
aws cloudfront create-invalidation --distribution-id E1OJBU6FBKY6X --paths "/*"
```

✅ **S3 にファイルをアップロードし、キャッシュをクリアすることで最新の変更が反映される**

---

## **🔎 動作確認**
```bash
https://d1zw3p63uw42m7.cloudfront.net/index.html
```
✅ **"Hello from S3 via CloudFront" が表示されれば成功 🎉**

---

## **✅ まとめ**
この PR では、以下の問題を解決しました。

### **🛠 修正内容**
1. **CloudFront の Origin Access Control (OAC) を作成**
2. **CloudFront のオリジン設定を修正**
3. **S3 バケットポリシーを適用し、CloudFront のみアクセス可能に**
4. **S3 のパブリックアクセス設定を適切に構成**
5. **テスト用 `index.html` を S3 にアップロード**
6. **CloudFront のキャッシュをクリアし、変更を即時適用**

### **📌 期待される動作**
- `https://d1zw3p63uw42m7.cloudfront.net/index.html` にアクセスすると、S3 の `index.html` が正常に表示される。
- **S3 の直接アクセスはブロックされ、CloudFront 経由のみアクセス可能。**
- **CloudFront の設定変更が即時反映されるよう、キャッシュを無効化。**

---

**✅ レビュー完了後のチェック**
☑ `index.html` にアクセスして動作確認  
☑ S3 のバケットポリシーが正しく適用されているか確認  
☑ CloudFront の設定が `Deployed` になっていることを確認  