### PR TITLE
#18 RDS（MySQL）のセットアップ

### DIFF
--- a/backend/lambda/devices/common/db.py
+++ b/backend/lambda/devices/common/db.py
@@ -29,10 +29,8 @@ def init_db():
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS devices (
                 id VARCHAR(36) PRIMARY KEY,
-                name VARCHAR(255) NOT NULL,
-                type VARCHAR(50) NOT NULL,
-                status VARCHAR(50) DEFAULT 'active',
-                location VARCHAR(255),
+                name VARCHAR(255) NOT NULL COMMENT '機器名',
+                manufacturer VARCHAR(255) NOT NULL COMMENT 'メーカー名',
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
             )
@@ -44,6 +42,3 @@ def init_db():
     finally:
         cursor.close()
         connection.close()
-
-# データベースの初期化（Lambda関数の初回実行時に実行される）
-init_db() 

--- a/backend/lambda/sql/init.sql
+++ b/backend/lambda/sql/init.sql
@@ -1,0 +1,27 @@
+-- デバイス管理用のデータベースを作成
+CREATE DATABASE IF NOT EXISTS lambdadb;
+USE lambdadb;
+
+-- デバイステーブルの作成
+CREATE TABLE IF NOT EXISTS devices (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL COMMENT '機器名',
+    manufacturer VARCHAR(255) NOT NULL COMMENT 'メーカー名',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- インデックスの作成
+CREATE INDEX idx_devices_name ON devices(name);
+CREATE INDEX idx_devices_manufacturer ON devices(manufacturer);
+
+-- コメントの追加
+ALTER TABLE devices
+    COMMENT = '機器管理用のテーブル';
+
+ALTER TABLE devices
+    MODIFY COLUMN id VARCHAR(36) COMMENT 'デバイスの一意識別子（UUID）',
+    MODIFY COLUMN name VARCHAR(255) COMMENT '機器名',
+    MODIFY COLUMN manufacturer VARCHAR(255) COMMENT 'メーカー名',
+    MODIFY COLUMN created_at TIMESTAMP COMMENT 'レコード作成日時',
+    MODIFY COLUMN updated_at TIMESTAMP COMMENT 'レコード更新日時';


### PR DESCRIPTION
## issue
- closes  #18

## 🔹 RDS（MySQL）対応

### 実装済みの項目
1. RDSインスタンスの作成
   - インスタンス名: `device-management-db`
   - エンドポイント: `device-management-db.c5gq8qo6cito.ap-northeast-1.rds.amazonaws.com`
   - ポート: 3306
   - データベース: `lambdadb`

2. セキュリティグループの設定
   - グループ名: `device-management-db-sg`
   - ID: `sg-02140cf26cca2034f`
   - インバウンドルール: MySQL/Aurora (3306)

3. データベーススキーマの定義
   ```sql
   -- backend/lambda/sql/init.sql
   CREATE DATABASE IF NOT EXISTS lambdadb;
   USE lambdadb;

   -- デバイステーブルの作成
   CREATE TABLE IF NOT EXISTS devices (
       id VARCHAR(36) PRIMARY KEY,
       name VARCHAR(255) NOT NULL COMMENT '機器名',
       manufacturer VARCHAR(255) NOT NULL COMMENT 'メーカー名',
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
   ```

4. データベース接続モジュールの作成
   ```python
   # backend/lambda/devices/common/db.py
   def get_db_connection():
       """データベース接続を取得する関数"""
       try:
           connection = mysql.connector.connect(
               host=os.getenv('DB_HOST'),
               user=os.getenv('DB_USER'),
               password=os.getenv('DB_PASSWORD'),
               database=os.getenv('DB_NAME')
           )
           return connection
       except mysql.connector.Error as err:
           print(f"データベース接続エラー: {err}")
           raise
