### PR TITLE
MySQL環境構築（Windows 11）

### DIFF
--- a/backend/lambda/devices/common/rds.py
+++ b/backend/lambda/devices/common/rds.py
@@ -1,54 +1,70 @@
 import os
-import mysql.connector
-from mysql.connector import Error
-from dotenv import load_dotenv
+import uuid
 import logging
 from typing import Dict, List, Optional
+from datetime import datetime
+import mysql.connector
+from dotenv import load_dotenv
 from .db_interface import DatabaseInterface
+
+# 環境変数の読み込み
+load_dotenv()
 
 # ロガーの設定
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-# 環境変数の読み込み
-load_dotenv()
-
 class RDSInterface(DatabaseInterface):
-    """RDS(MySQL)を使用したデバイス管理クラス"""
+    """RDS（MySQL）インターフェースの実装クラス"""
     
     def __init__(self):
-        """データベース接続を初期化"""
+        """データベース接続の初期化"""
         try:
             self.connection = mysql.connector.connect(
-                host=os.getenv('DB_HOST'),
-                user=os.getenv('DB_USER'),
-                password=os.getenv('DB_PASSWORD'),
-                database=os.getenv('DB_NAME')
+                host=os.getenv('RDS_HOST'),
+                user=os.getenv('RDS_USER'),
+                password=os.getenv('RDS_PASSWORD'),
+                database=os.getenv('RDS_DATABASE'),
+                port=int(os.getenv('RDS_PORT', '3306'))
             )
-            logger.info(f"RDSデータベース {os.getenv('DB_NAME')} に接続しました")
-        except Error as e:
+            self.connection.autocommit = True
+            logger.info(f"RDSデータベース {os.getenv('RDS_DATABASE')} に接続しました")
+        except mysql.connector.Error as e:
             logger.error(f"データベース接続エラー: {str(e)}")
             raise
 
-    def __del__(self):
-        """デストラクタ: 接続を閉じる"""
-        if hasattr(self, 'connection') and self.connection.is_connected():
-            self.connection.close()
-            logger.info("データベース接続を閉じました")
+    def _get_cursor(self):
+        """カーソルを取得し、必要に応じて再接続する"""
+        try:
+            self.connection.ping(reconnect=True, attempts=3, delay=5)
+            return self.connection.cursor(dictionary=True)
+        except mysql.connector.Error as e:
+            logger.error(f"データベース接続エラー: {str(e)}")
+            raise
 
     def create_device(self, device_data: Dict) -> Dict:
         """デバイスを作成する"""
-        cursor = self.connection.cursor(dictionary=True)
+        cursor = self._get_cursor()
         try:
+            device_id = str(uuid.uuid4())
+            now = datetime.utcnow()
+            
             query = """
-                INSERT INTO devices (id, name, manufacturer)
-                VALUES (%(id)s, %(name)s, %(manufacturer)s)
+                INSERT INTO devices (id, name, manufacturer, created_at, updated_at)
+                VALUES (%s, %s, %s, %s, %s)
             """
-            cursor.execute(query, device_data)
+            cursor.execute(query, (
+                device_id,
+                device_data['name'],
+                device_data['manufacturer'],
+                now,
+                now
+            ))
             self.connection.commit()
-            logger.info(f"デバイスを作成しました: {device_data['id']}")
-            return device_data
-        except Error as e:
+            
+            # 作成したデバイスを取得して返す
+            return self.get_device(device_id)
+        except mysql.connector.Error as e:
             logger.error(f"デバイス作成エラー: {str(e)}")
             raise
         finally:
@@ -56,7 +72,7 @@ class RDSInterface(DatabaseInterface):
 
     def get_device(self, device_id: str) -> Optional[Dict]:
         """デバイスを取得する"""
-        cursor = self.connection.cursor(dictionary=True)
+        cursor = self._get_cursor()
         try:
             query = "SELECT * FROM devices WHERE id = %s"
             cursor.execute(query, (device_id,))
@@ -66,7 +82,7 @@ class RDSInterface(DatabaseInterface):
             else:
                 logger.info(f"デバイスが見つかりません: {device_id}")
             return device
-        except Error as e:
+        except mysql.connector.Error as e:
             logger.error(f"デバイス取得エラー: {str(e)}")
             raise
         finally:
@@ -74,7 +90,7 @@ class RDSInterface(DatabaseInterface):
 
     def update_device(self, device_id: str, update_data: Dict) -> Optional[Dict]:
         """デバイスを更新する"""
-        cursor = self.connection.cursor(dictionary=True)
+        cursor = self._get_cursor()
         try:
             # 更新可能なフィールドを指定
             allowed_fields = ['name', 'manufacturer']
@@ -86,22 +102,18 @@ class RDSInterface(DatabaseInterface):
             
             # UPDATE文の構築
             set_clause = ", ".join([f"{field} = %s" for field in update_fields.keys()])
-            query = f"UPDATE devices SET {set_clause} WHERE id = %s"
+            query = f"UPDATE devices SET {set_clause}, updated_at = %s WHERE id = %s"
             
             # パラメータの準備
-            params = list(update_fields.values()) + [device_id]
+            params = list(update_fields.values()) + [datetime.utcnow(), device_id]
             
             # 更新の実行
             cursor.execute(query, params)
             self.connection.commit()
             
-            # 更新後のデータを取得
-            cursor.execute("SELECT * FROM devices WHERE id = %s", (device_id,))
-            updated_device = cursor.fetchone()
-            
-            logger.info(f"デバイスを更新しました: {device_id}")
-            return updated_device
-        except Error as e:
+            # 更新後のデータを取得して返す
+            return self.get_device(device_id)
+        except mysql.connector.Error as e:
             logger.error(f"デバイス更新エラー: {str(e)}")
             raise
         finally:
@@ -109,7 +121,7 @@ class RDSInterface(DatabaseInterface):
 
     def delete_device(self, device_id: str) -> bool:
         """デバイスを削除する"""
-        cursor = self.connection.cursor()
+        cursor = self._get_cursor()
         try:
             query = "DELETE FROM devices WHERE id = %s"
             cursor.execute(query, (device_id,))
@@ -120,7 +132,7 @@ class RDSInterface(DatabaseInterface):
             else:
                 logger.info(f"削除対象のデバイスが見つかりません: {device_id}")
             return deleted
-        except Error as e:
+        except mysql.connector.Error as e:
             logger.error(f"デバイス削除エラー: {str(e)}")
             raise
         finally:
@@ -128,15 +140,21 @@ class RDSInterface(DatabaseInterface):
 
     def list_devices(self) -> List[Dict]:
         """全デバイスを取得する"""
-        cursor = self.connection.cursor(dictionary=True)
+        cursor = self._get_cursor()
         try:
             query = "SELECT * FROM devices"
             cursor.execute(query)
             devices = cursor.fetchall()
             logger.info(f"デバイス一覧を取得しました: {len(devices)}件")
             return devices
-        except Error as e:
+        except mysql.connector.Error as e:
             logger.error(f"デバイス一覧取得エラー: {str(e)}")
             raise
         finally:
-            cursor.close() 
+            cursor.close()
+
+    def __del__(self):
+        """デストラクタ：接続のクリーンアップ"""
+        if hasattr(self, 'connection') and self.connection.is_connected():
+            self.connection.close()
+            logger.info("データベース接続を閉じました") 


### PR DESCRIPTION
## issue
- closes  #　再トライ

# feature/18-setup-rds-mysql-retry

# 🔧 機器管理システム

[... existing content ...]

# ✅ MySQL環境構築（Windows 11）

## 📝 概要
この手順では、Windows 11環境でMySQLをセットアップし、アプリケーションから接続できる状態にするまでの手順を説明します。

## 📌 1. MySQLのインストール
### ✅ MySQL Installerのダウンロード & インストール
1. [MySQL公式サイト](https://dev.mysql.com/downloads/installer/)からMySQL Installerをダウンロード
2. インストーラーを実行し、以下の項目を選択：
   - MySQL Server 8.0
   - MySQL Workbench
   - MySQL Shell
   - Connector/Python

### ✅ サーバー設定
1. **Windows Service設定**
   - Configure MySQL Server as a Windows Service: ✓
   - Service Name: MySQL80
   - Start the MySQL Server at System Startup: ✓
   - Standard System Account: ✓

2. **認証設定**
   - Authentication Method: Use Strong Password Encryption
   - Root Password: 設定したパスワードを安全に保管

## 📌 2. データベースとテーブルの作成
### ✅ MySQL Workbenchでの接続設定
1. MySQL Workbenchを起動
2. 「+」ボタンで新規接続を作成：
   - Connection Name: Local MySQL80
   - Hostname: localhost
   - Port: 3306
   - Username: root
   - Password: 設定したパスワード
   - Default Schema: lambdadb

### ✅ データベースとテーブルの作成
```sql
-- データベース作成
CREATE DATABASE lambdadb;
USE lambdadb;

-- デバイステーブルの作成
CREATE TABLE devices (
    id VARCHAR(36) PRIMARY KEY,
    name VARCHAR(255) NOT NULL COMMENT '機器名',
    manufacturer VARCHAR(255) NOT NULL COMMENT 'メーカー名',
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

-- インデックスの作成
CREATE INDEX idx_devices_name ON devices(name);
CREATE INDEX idx_devices_manufacturer ON devices(manufacturer);

-- テーブルコメントの設定
ALTER TABLE devices COMMENT = '機器管理用のテーブル';
```

## 📌 3. アプリケーション設定
### ✅ 環境変数の設定
`backend/.env`ファイルに以下の設定を追加：
```
# データベース設定
DB_TYPE=rds

# RDS設定
RDS_HOST=localhost
RDS_PORT=3306
RDS_USER=root
RDS_PASSWORD=your_password
RDS_DATABASE=lambdadb
```

### ✅ 動作確認
1. テストデータの挿入：
```sql
INSERT INTO devices (id, name, manufacturer) VALUES 
(UUID(), 'エアコン', 'パナソニック'),
(UUID(), '冷蔵庫', '日立'),
(UUID(), '洗濯機', 'シャープ');
```

2. Pythonスクリプトでの接続テスト：
```bash
cd backend/lambda
python devices/scripts/insert_test_data.py
```

## 📌 4. トラブルシューティング
### ✅ よくあるエラーと解決策
1. **Access denied for user 'root'@'localhost'**
   - MySQLのrootパスワードが正しく設定されているか確認
   - `.env`ファイルのパスワードが正しいか確認

2. **Can't connect to MySQL server on 'localhost'**
   - MySQL Serverが起動しているか確認
   - ポート3306が使用可能か確認