### PR TITLE
#24/4.5 エラーハンドリングの実装

### DIFF
--- a/backend/lambda/devices/common/error_handlers.py
+++ b/backend/lambda/devices/common/error_handlers.py
@@ -1,0 +1,50 @@
+from fastapi import Request
+from fastapi.responses import JSONResponse
+import logging
+from .exceptions import DeviceManagementError
+
+# ロガーの設定
+logger = logging.getLogger(__name__)
+
+async def device_management_exception_handler(
+    request: Request,
+    exc: DeviceManagementError
+) -> JSONResponse:
+    """カスタム例外のハンドラー"""
+    logger.error(
+        f"エラーが発生しました - コード: {exc.error_code}, "
+        f"メッセージ: {exc.message}, "
+        f"詳細: {exc.details}"
+    )
+    
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={
+            "error": {
+                "code": exc.error_code,
+                "message": exc.message,
+                "details": exc.details
+            }
+        }
+    )
+
+async def general_exception_handler(
+    request: Request,
+    exc: Exception
+) -> JSONResponse:
+    """一般的な例外のハンドラー"""
+    logger.error(f"予期せぬエラーが発生しました: {str(exc)}")
+    
+    return JSONResponse(
+        status_code=500,
+        content={
+            "error": {
+                "code": "INTERNAL_ERROR",
+                "message": "内部サーバーエラーが発生しました",
+                "details": {
+                    "type": exc.__class__.__name__,
+                    "message": str(exc)
+                }
+            }
+        }
+    ) 

--- a/backend/lambda/devices/common/exceptions.py
+++ b/backend/lambda/devices/common/exceptions.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict, Optional
+
+class DeviceManagementError(Exception):
+    """基本となるカスタム例外クラス"""
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 500,
+        error_code: str = "INTERNAL_ERROR",
+        details: Optional[Dict[str, Any]] = None
+    ):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.error_code = error_code
+        self.details = details or {}
+
+class DeviceNotFoundError(DeviceManagementError):
+    """デバイスが見つからない場合の例外"""
+    def __init__(self, device_id: str):
+        super().__init__(
+            message=f"デバイスが見つかりません: {device_id}",
+            status_code=404,
+            error_code="DEVICE_NOT_FOUND",
+            details={"device_id": device_id}
+        )
+
+class ValidationError(DeviceManagementError):
+    """入力バリデーションエラーの例外"""
+    def __init__(self, message: str, details: Dict[str, Any]):
+        super().__init__(
+            message=message,
+            status_code=400,
+            error_code="VALIDATION_ERROR",
+            details=details
+        )
+
+class DatabaseError(DeviceManagementError):
+    """データベース操作エラーの例外"""
+    def __init__(self, message: str, original_error: Optional[Exception] = None):
+        details = {"original_error": str(original_error)} if original_error else {}
+        super().__init__(
+            message=message,
+            status_code=500,
+            error_code="DATABASE_ERROR",
+            details=details
+        ) 

--- a/backend/lambda/devices/handlers/device_handlers.py
+++ b/backend/lambda/devices/handlers/device_handlers.py
@@ -7,6 +7,11 @@ from ..models import Device
 from ..schemas import DeviceCreate, Device as DeviceSchema
 from fastapi.responses import JSONResponse
 import uuid
+from ..common.exceptions import DeviceNotFoundError, ValidationError, DatabaseError
+import logging
+
+# ロガーの設定
+logger = logging.getLogger(__name__)
 
 class UnicodeJSONResponse(JSONResponse):
     def render(self, content) -> bytes:
@@ -23,86 +28,143 @@ router = APIRouter()
 @router.post("/devices/", response_model=DeviceSchema, status_code=201)
 def create_device(device: DeviceCreate, db: Session = Depends(get_db)):
     """新しいデバイスを作成"""
-    db_device = Device(
-        id=str(uuid.uuid4()),
-        name=device.name,
-        manufacturer=device.manufacturer
-    )
-    db.add(db_device)
-    db.commit()
-    db.refresh(db_device)
-    return UnicodeJSONResponse(
-        content={
-            "name": db_device.name,
-            "manufacturer": db_device.manufacturer,
-            "id": db_device.id,
-            "created_at": db_device.created_at.isoformat(),
-            "updated_at": db_device.updated_at.isoformat()
-        },
-        status_code=201
-    )
+    try:
+        # 入力バリデーション
+        if not device.name:
+            raise ValidationError("デバイス名は必須です", {"field": "name"})
+        if not device.manufacturer:
+            raise ValidationError("メーカー名は必須です", {"field": "manufacturer"})
+
+        db_device = Device(
+            id=str(uuid.uuid4()),
+            name=device.name,
+            manufacturer=device.manufacturer
+        )
+        
+        try:
+            db.add(db_device)
+            db.commit()
+            db.refresh(db_device)
+        except Exception as e:
+            logger.error(f"データベースエラー: {str(e)}")
+            raise DatabaseError("デバイスの作成中にエラーが発生しました", e)
+
+        return UnicodeJSONResponse(
+            content={
+                "name": db_device.name,
+                "manufacturer": db_device.manufacturer,
+                "id": db_device.id,
+                "created_at": db_device.created_at.isoformat(),
+                "updated_at": db_device.updated_at.isoformat()
+            },
+            status_code=201
+        )
+    except ValidationError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"予期せぬエラー: {str(e)}")
+        raise
 
 @router.get("/devices/", response_model=List[DeviceSchema])
 def list_devices(db: Session = Depends(get_db)):
     """全デバイスを取得"""
-    devices = db.query(Device).all()
-    return UnicodeJSONResponse(
-        content=[{
-            "name": device.name,
-            "manufacturer": device.manufacturer,
-            "id": device.id,
-            "created_at": device.created_at.isoformat(),
-            "updated_at": device.updated_at.isoformat()
-        } for device in devices]
-    )
+    try:
+        devices = db.query(Device).all()
+        return UnicodeJSONResponse(
+            content=[{
+                "name": device.name,
+                "manufacturer": device.manufacturer,
+                "id": device.id,
+                "created_at": device.created_at.isoformat(),
+                "updated_at": device.updated_at.isoformat()
+            } for device in devices]
+        )
+    except Exception as e:
+        logger.error(f"デバイス一覧取得エラー: {str(e)}")
+        raise DatabaseError("デバイス一覧の取得中にエラーが発生しました", e)
 
 @router.get("/devices/{device_id}", response_model=DeviceSchema)
 def get_device(device_id: str, db: Session = Depends(get_db)):
     """指定されたIDのデバイスを取得"""
-    device = db.query(Device).filter(Device.id == device_id).first()
-    if device is None:
-        raise HTTPException(status_code=404, detail="指定されたデバイスが見つかりません")
-    return UnicodeJSONResponse(
-        content={
-            "name": device.name,
-            "manufacturer": device.manufacturer,
-            "id": device.id,
-            "created_at": device.created_at.isoformat(),
-            "updated_at": device.updated_at.isoformat()
-        }
-    )
+    try:
+        device = db.query(Device).filter(Device.id == device_id).first()
+        if device is None:
+            raise DeviceNotFoundError(device_id)
+
+        return UnicodeJSONResponse(
+            content={
+                "name": device.name,
+                "manufacturer": device.manufacturer,
+                "id": device.id,
+                "created_at": device.created_at.isoformat(),
+                "updated_at": device.updated_at.isoformat()
+            }
+        )
+    except DeviceNotFoundError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"デバイス取得エラー: {str(e)}")
+        raise DatabaseError("デバイスの取得中にエラーが発生しました", e)
 
 @router.put("/devices/{device_id}", response_model=DeviceSchema)
 def update_device(device_id: str, device: DeviceCreate, db: Session = Depends(get_db)):
     """デバイスを更新"""
-    db_device = db.query(Device).filter(Device.id == device_id).first()
-    if db_device is None:
-        raise HTTPException(status_code=404, detail="指定されたデバイスが見つかりません")
-    
-    for key, value in device.dict().items():
-        setattr(db_device, key, value)
-    
-    db.commit()
-    db.refresh(db_device)
-    return UnicodeJSONResponse(
-        content={
-            "name": db_device.name,
-            "manufacturer": db_device.manufacturer,
-            "id": db_device.id,
-            "created_at": db_device.created_at.isoformat(),
-            "updated_at": db_device.updated_at.isoformat()
-        }
-    )
+    try:
+        # 入力バリデーション
+        if not device.name:
+            raise ValidationError("デバイス名は必須です", {"field": "name"})
+        if not device.manufacturer:
+            raise ValidationError("メーカー名は必須です", {"field": "manufacturer"})
+
+        db_device = db.query(Device).filter(Device.id == device_id).first()
+        if db_device is None:
+            raise DeviceNotFoundError(device_id)
+        
+        for key, value in device.dict().items():
+            setattr(db_device, key, value)
+        
+        try:
+            db.commit()
+            db.refresh(db_device)
+        except Exception as e:
+            logger.error(f"データベースエラー: {str(e)}")
+            raise DatabaseError("デバイスの更新中にエラーが発生しました", e)
+
+        return UnicodeJSONResponse(
+            content={
+                "name": db_device.name,
+                "manufacturer": db_device.manufacturer,
+                "id": db_device.id,
+                "created_at": db_device.created_at.isoformat(),
+                "updated_at": db_device.updated_at.isoformat()
+            }
+        )
+    except (ValidationError, DeviceNotFoundError) as e:
+        raise e
+    except Exception as e:
+        logger.error(f"予期せぬエラー: {str(e)}")
+        raise
 
 @router.delete("/devices/{device_id}")
 def delete_device(device_id: str, db: Session = Depends(get_db)):
     """デバイスを削除"""
-    db_device = db.query(Device).filter(Device.id == device_id).first()
-    if db_device is None:
-        raise HTTPException(status_code=404, detail="指定されたデバイスが見つかりません")
-    
-    db.delete(db_device)
-    db.commit()
-    return UnicodeJSONResponse(
-        content={"message": "デバイスを削除しました", "device_id": device_id}
-    ) 
+    try:
+        db_device = db.query(Device).filter(Device.id == device_id).first()
+        if db_device is None:
+            raise DeviceNotFoundError(device_id)
+        
+        try:
+            db.delete(db_device)
+            db.commit()
+        except Exception as e:
+            logger.error(f"データベースエラー: {str(e)}")
+            raise DatabaseError("デバイスの削除中にエラーが発生しました", e)
+
+        return UnicodeJSONResponse(
+            content={"message": "デバイスを削除しました", "device_id": device_id}
+        )
+    except DeviceNotFoundError as e:
+        raise e
+    except Exception as e:
+        logger.error(f"予期せぬエラー: {str(e)}")
+        raise 

--- a/backend/lambda/devices/main.py
+++ b/backend/lambda/devices/main.py
@@ -5,6 +5,8 @@ from .handlers import device_handlers
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 import json
+from .common.exceptions import DeviceManagementError
+from .common.error_handlers import device_management_exception_handler, general_exception_handler
 
 class UnicodeJSONResponse(JSONResponse):
     def render(self, content) -> bytes:
@@ -22,6 +24,10 @@ app = FastAPI(
     version="1.0.0",
     default_response_class=UnicodeJSONResponse
 )
+
+# エラーハンドラーの登録
+app.add_exception_handler(DeviceManagementError, device_management_exception_handler)
+app.add_exception_handler(Exception, general_exception_handler)
 
 # CORS設定
 app.add_middleware(

--- a/backend/lambda/tests/conftest.py
+++ b/backend/lambda/tests/conftest.py
@@ -1,0 +1,51 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import sys
+import os
+from pathlib import Path
+
+# プロジェクトルートをPythonパスに追加
+project_root = str(Path(__file__).parent.parent)
+sys.path.insert(0, project_root)
+
+from devices.database import Base
+from devices.main import app
+from fastapi.testclient import TestClient
+from dotenv import load_dotenv
+
+# テスト用の環境変数を設定
+os.environ["DB_TYPE"] = "rds"
+os.environ["RDS_HOST"] = "localhost"
+os.environ["RDS_PORT"] = "3306"
+os.environ["RDS_USER"] = "root"
+os.environ["RDS_PASSWORD"] = "okitasouji"
+os.environ["RDS_DATABASE"] = "test_lambdadb"
+
+# テスト用のデータベースURL
+SQLALCHEMY_DATABASE_URL = "mysql+mysqlconnector://root:okitasouji@localhost:3306/test_lambdadb"
+
+@pytest.fixture(scope="session")
+def test_db():
+    """テスト用データベースのセットアップとクリーンアップ"""
+    # テスト用データベースの作成
+    engine = create_engine(
+        SQLALCHEMY_DATABASE_URL,
+        pool_pre_ping=True
+    )
+    
+    # テーブルの作成
+    Base.metadata.create_all(bind=engine)
+    
+    # テスト用セッションの作成
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    
+    yield engine
+    
+    # テスト後のクリーンアップ
+    Base.metadata.drop_all(bind=engine)
+
+@pytest.fixture
+def test_client():
+    """テストクライアントを提供"""
+    return TestClient(app) 

--- a/backend/lambda/tests/test_error_handling.py
+++ b/backend/lambda/tests/test_error_handling.py
@@ -1,0 +1,71 @@
+import pytest
+from fastapi.testclient import TestClient
+import sys
+import os
+from pathlib import Path
+
+# プロジェクトルートをPythonパスに追加
+project_root = str(Path(__file__).parent.parent)
+sys.path.insert(0, project_root)
+
+from devices.main import app
+from devices.common.exceptions import DeviceNotFoundError, ValidationError, DatabaseError
+
+client = TestClient(app)
+
+def test_device_not_found_error():
+    """存在しないデバイスへのアクセスで404エラーが返されることを確認"""
+    response = client.get("/api/v1/devices/non-existent-id")
+    assert response.status_code == 404
+    
+    error_response = response.json()
+    assert "error" in error_response
+    assert error_response["error"]["code"] == "DEVICE_NOT_FOUND"
+    assert "non-existent-id" in error_response["error"]["message"]
+
+def test_validation_error_create_device():
+    """デバイス作成時の入力バリデーションエラーを確認"""
+    # 名前が空の場合
+    response = client.post(
+        "/api/v1/devices/",
+        json={"name": "", "manufacturer": "テストメーカー"}
+    )
+    assert response.status_code == 400
+    
+    error_response = response.json()
+    assert error_response["error"]["code"] == "VALIDATION_ERROR"
+    assert "デバイス名は必須です" in error_response["error"]["message"]
+    
+    # メーカー名が空の場合
+    response = client.post(
+        "/api/v1/devices/",
+        json={"name": "テストデバイス", "manufacturer": ""}
+    )
+    assert response.status_code == 400
+    
+    error_response = response.json()
+    assert error_response["error"]["code"] == "VALIDATION_ERROR"
+    assert "メーカー名は必須です" in error_response["error"]["message"]
+
+def test_validation_error_update_device():
+    """デバイス更新時の入力バリデーションエラーを確認"""
+    response = client.put(
+        "/api/v1/devices/test-id",
+        json={"name": "", "manufacturer": "テストメーカー"}
+    )
+    assert response.status_code == 400
+    
+    error_response = response.json()
+    assert error_response["error"]["code"] == "VALIDATION_ERROR"
+    assert "デバイス名は必須です" in error_response["error"]["message"]
+
+def test_successful_error_response_format():
+    """エラーレスポンスの形式が正しいことを確認"""
+    response = client.get("/api/v1/devices/non-existent-id")
+    assert response.status_code == 404
+    
+    error_response = response.json()
+    assert "error" in error_response
+    assert "code" in error_response["error"]
+    assert "message" in error_response["error"]
+    assert "details" in error_response["error"] 


### PR DESCRIPTION
## issue
- closes  #24 

# ✅ エラーハンドリング実装の成果

## 📝 実装した機能
1. カスタム例外クラスの作成
   - `DeviceManagementError`: 基本となる例外クラス
   - `DeviceNotFoundError`: 404エラー用
   - `ValidationError`: 400エラー用
   - `DatabaseError`: 500エラー用

2. エラーハンドラーの実装
   - カスタム例外用ハンドラー
   - 一般的な例外用ハンドラー
   - 適切なログ出力機能

3. エラーレスポンスの標準化
```json
{
    "error": {
        "code": "ERROR_CODE",
        "message": "エラーメッセージ",
        "details": {
            // エラーの詳細情報
        }
    }
}
```

## ✅ テスト結果
すべてのテストケースが成功：
1. `test_device_not_found_error`: 404エラーの確認
2. `test_validation_error_create_device`: 作成時の400エラー
3. `test_validation_error_update_device`: 更新時の400エラー
4. `test_successful_error_response_format`: レスポンス形式の確認

## 🔍 確認ポイント
- エラーメッセージの日本語対応
- 適切なHTTPステータスコードの設定
- エラーログの出力
- 一貫したレスポンス形式