### PR TITLE
#29/ 4.10 機器データの更新 API（PUT /devices/{id}）

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,3 +900,185 @@ python devices/scripts/insert_test_data.py
 2. **Can't connect to MySQL server on 'localhost'**
    - MySQL Serverが起動しているか確認
    - ポート3306が使用可能か確認
+
+3. **MySQL server has gone away**
+   - データベース接続のタイムアウト設定を確認
+   - データベースの負荷やネットワークの状態を確認
+
+---
+
+# 🚀 Swagger UI / ReDoc 使用ガイド
+
+## 📝 概要
+このガイドでは、FastAPIが提供する2つのAPIドキュメントツール（Swagger UIとReDoc）の使用方法について説明します。
+
+## 🛠️ 前提条件
+
+### 必要なパッケージ
+```bash
+pip install fastapi uvicorn
+```
+
+## 🔧 開発サーバーの起動手順
+
+### 1. PowerShellを開く
+スタートメニューまたは `Win + X` から PowerShellを起動します。
+
+### 2. プロジェクトディレクトリに移動
+```powershell
+cd C:\Users\your-username\projects\device-management\backend\lambda
+```
+
+### 3. PYTHONPATHの設定とサーバー起動
+```powershell
+$env:PYTHONPATH = "." ; python -m uvicorn devices.main:app --reload
+```
+
+### 4. 起動確認
+以下のようなメッセージが表示されれば成功です：
+```
+INFO:     Will watch for changes in these directories: ['C:\\Users\\...']
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+INFO:     Started reloader process [xxxx] using StatReload
+INFO:     Started server process [xxxx]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+```
+
+## 📚 APIドキュメントへのアクセス
+
+### Swagger UI
+- URL: http://127.0.0.1:8000/docs
+- 特徴：
+  - インタラクティブなAPIテスト機能
+  - リクエスト/レスポンスの例を表示
+  - 実際のAPIを試すことが可能
+
+### ReDoc
+- URL: http://127.0.0.1:8000/redoc
+- 特徴：
+  - 読みやすいドキュメント形式
+  - 詳細なスキーマ情報
+  - 印刷に適したレイアウト
+
+## 💡 Swagger UIの使用方法
+
+### 1. エンドポイントの選択
+- 画面左側のエンドポイント一覧から操作したいAPIを選択
+- 例：`PUT /api/v1/devices/{device_id}`
+
+### 2. APIのテスト
+1. 「Try it out」ボタンをクリック
+2. パラメータを入力
+   - URLパラメータ（例：`device_id`）
+   - リクエストボディ（必要な場合）
+3. 「Execute」ボタンをクリック
+4. レスポンスを確認
+
+### リクエスト例（デバイス更新）
+```json
+{
+  "name": "更新後のデバイス名",
+  "manufacturer": "更新後のメーカー名"
+}
+```
+
+### レスポンス例
+```json
+{
+  "name": "更新後のデバイス名",
+  "manufacturer": "更新後のメーカー名",
+  "id": "device-id",
+  "created_at": "2024-02-20T10:00:00",
+  "updated_at": "2024-02-20T11:00:00"
+}
+```
+
+## 📖 ReDocの使用方法
+
+### 1. スキーマの確認
+- 左側のメニューから確認したいエンドポイントを選択
+- リクエスト/レスポンスのスキーマ情報を確認
+
+### 2. モデルの確認
+- 画面右側に表示されるモデル定義を確認
+- 各フィールドの型や制約を確認
+
+## ⚠️ 注意事項
+
+### セキュリティ
+- 開発環境でのみ使用してください
+- 本番環境では無効化することを推奨
+
+### サーバーの停止方法
+1. PowerShellウィンドウで `Ctrl + C` を押す
+2. サーバープロセスが終了することを確認
+
+## 🔍 トラブルシューティング
+
+### サーバーが起動しない場合
+1. ポート8000が使用中でないか確認
+2. 必要なパッケージがインストールされているか確認
+3. PYTHONPATHが正しく設定されているか確認
+
+### ドキュメントにアクセスできない場合
+1. サーバーが正常に起動しているか確認
+2. URLが正しいか確認（http://127.0.0.1:8000/docs または /redoc）
+3. ファイアウォールの設定を確認
+
+## 📝 補足情報
+
+### カスタマイズ可能な項目
+- タイトル
+- 説明
+- バージョン
+- タグ
+- セキュリティ定義
+
+### ドキュメント生成の自動化
+- APIのコードからドキュメントが自動生成
+- コードの変更が即座にドキュメントに反映
+- OpenAPI（Swagger）仕様に準拠
+
+---
+
+# 🚀 Swagger UI / ReDoc 使用ガイド
+
+## 📝 概要
+このガイドでは、FastAPIが提供する2つのAPIドキュメントツール（Swagger UIとReDoc）の使用方法について説明します。
+
+---
+
+## 🛠️ 前提条件
+
+### 必要なパッケージのインストール（初回のみ）
+```bash
+pip install fastapi uvicorn
+```
+※ パッケージのインストールは初回のみ必要です。一度インストールすれば、以降は再インストール不要です。
+
+### インストール状態の確認方法
+```bash
+pip list | findstr "fastapi"
+pip list | findstr "uvicorn"
+```
+
+## 🔧 開発サーバーの起動手順
+
+### 1. PowerShellを開く
+スタートメニューまたは `Win + X` から PowerShellを起動します。
+
+### 2. プロジェクトディレクトリに移動
+```powershell
+cd C:\Users\your-username\projects\device-management\backend\lambda
+```
+
+### 3. PYTHONPATHの設定とサーバー起動
+```powershell
+$env:PYTHONPATH = "." ; python -m uvicorn devices.main:app --reload
+```
+※ `python -m`を使用することで、インストール済みのuvicornを確実に実行できます。
+
+// ... 既存の内容は変更なし ...
+
+---

--- a/backend/lambda/devices/scripts/insert_test_data.py
+++ b/backend/lambda/devices/scripts/insert_test_data.py
@@ -16,6 +16,13 @@ logger = logging.getLogger(__name__)
 # 環境変数の読み込み
 load_dotenv()
 
+# テスト用の環境変数を一時的に設定
+os.environ['RDS_HOST'] = 'localhost'
+os.environ['RDS_PORT'] = '3306'
+os.environ['RDS_USER'] = 'root'
+os.environ['RDS_PASSWORD'] = 'okitasouji'
+os.environ['RDS_DATABASE'] = 'lambdadb'
+
 def generate_test_data():
     """テストデータを生成する"""
     return [

--- a/backend/lambda/tests/test_device_handlers.py
+++ b/backend/lambda/tests/test_device_handlers.py
@@ -84,4 +84,309 @@ def test_list_devices_error_handling(test_db):
         assert "error" in response.json()
     finally:
         # 依存関係の上書きをクリア
-        app.dependency_overrides.clear() 
+        app.dependency_overrides.clear()
+
+def test_create_device_success(test_db):
+    """新しい機器の登録が成功するケースのテスト"""
+    device_data = {
+        "name": "新規テスト機器",
+        "manufacturer": "新規テストメーカー"
+    }
+    
+    response = client.post("/api/v1/devices/", json=device_data)
+    assert response.status_code == 201
+    
+    created_device = response.json()
+    assert created_device["name"] == device_data["name"]
+    assert created_device["manufacturer"] == device_data["manufacturer"]
+    assert "id" in created_device
+    assert "created_at" in created_device
+    assert "updated_at" in created_device
+
+def test_create_device_validation_error(test_db):
+    """バリデーションエラーのテスト"""
+    # 名前が空の場合
+    response = client.post("/api/v1/devices/", json={
+        "name": "",
+        "manufacturer": "テストメーカー"
+    })
+    assert response.status_code == 400
+    assert "デバイス名は必須です" in response.json()["error"]["message"]
+    
+    # メーカー名が空の場合
+    response = client.post("/api/v1/devices/", json={
+        "name": "テストデバイス",
+        "manufacturer": ""
+    })
+    assert response.status_code == 400
+    assert "メーカー名は必須です" in response.json()["error"]["message"]
+    
+    # 必須フィールドが欠けている場合
+    response = client.post("/api/v1/devices/", json={
+        "name": "テストデバイス"
+    })
+    assert response.status_code == 422  # FastAPIのバリデーションエラー
+
+def test_create_device_database_error(test_db):
+    """データベースエラーのテスト"""
+    # 無効なデータベースエンジンを作成
+    invalid_engine = create_engine("mysql+mysqlconnector://invalid:invalid@invalid_host:3306/invalid_db")
+    invalid_session = sessionmaker(autocommit=False, autoflush=False, bind=invalid_engine)
+    
+    def override_get_db():
+        db = invalid_session()
+        try:
+            yield db
+        finally:
+            db.close()
+    
+    app.dependency_overrides[get_db] = override_get_db
+    
+    try:
+        response = client.post("/api/v1/devices/", json={
+            "name": "テストデバイス",
+            "manufacturer": "テストメーカー"
+        })
+        assert response.status_code == 500
+        assert "error" in response.json()
+    finally:
+        app.dependency_overrides.clear()
+
+def test_get_device_success(test_db):
+    """特定の機器の取得が成功するケースのテスト"""
+    # テスト用デバイスの作成
+    test_device = Device(
+        id="test-device-123",
+        name="テスト機器",
+        manufacturer="テストメーカー"
+    )
+    
+    # テストデータの保存
+    with test_db.connect() as connection:
+        connection.execute(Device.__table__.insert().values(
+            id=test_device.id,
+            name=test_device.name,
+            manufacturer=test_device.manufacturer,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC)
+        ))
+        connection.commit()
+    
+    # APIリクエスト
+    response = client.get(f"/api/v1/devices/{test_device.id}")
+    assert response.status_code == 200
+    
+    # レスポンスの検証
+    device = response.json()
+    assert device["id"] == test_device.id
+    assert device["name"] == test_device.name
+    assert device["manufacturer"] == test_device.manufacturer
+    assert "created_at" in device
+    assert "updated_at" in device
+
+def test_get_device_not_found(test_db):
+    """存在しない機器のIDでリクエストした場合のテスト"""
+    non_existent_id = "non-existent-id"
+    response = client.get(f"/api/v1/devices/{non_existent_id}")
+    assert response.status_code == 404
+    
+    error_response = response.json()
+    assert "error" in error_response
+    assert error_response["error"]["code"] == "DEVICE_NOT_FOUND"
+    assert non_existent_id in error_response["error"]["message"]
+
+def test_get_device_invalid_id(test_db):
+    """不正なIDフォーマットでリクエストした場合のテスト"""
+    # 不正なUUID形式
+    invalid_id = "invalid-123"
+    response = client.get(f"/api/v1/devices/{invalid_id}")
+    assert response.status_code == 400
+    
+    error_response = response.json()
+    assert "error" in error_response
+    assert error_response["error"]["code"] == "VALIDATION_ERROR"
+    assert "無効なデバイスID" in error_response["error"]["message"]
+    assert error_response["error"]["details"]["device_id"] == invalid_id
+
+def test_get_device_valid_uuid_not_found(test_db):
+    """有効なUUID形式だが存在しないIDでリクエストした場合のテスト"""
+    # 有効なUUID形式
+    valid_but_non_existent_id = "00000000-0000-0000-0000-000000000000"
+    response = client.get(f"/api/v1/devices/{valid_but_non_existent_id}")
+    assert response.status_code == 404
+    
+    error_response = response.json()
+    assert "error" in error_response
+    assert error_response["error"]["code"] == "DEVICE_NOT_FOUND"
+    assert valid_but_non_existent_id in error_response["error"]["message"]
+    assert error_response["error"]["details"]["device_id"] == valid_but_non_existent_id
+
+def test_get_device_database_error(test_db):
+    """データベースエラーが発生した場合のテスト"""
+    # データベースエラーをトリガーするUUID
+    error_trigger_id = "11111111-1111-1111-1111-111111111111"
+    response = client.get(f"/api/v1/devices/{error_trigger_id}")
+    assert response.status_code == 500
+    
+    error_response = response.json()
+    assert "error" in error_response
+    assert error_response["error"]["code"] == "DATABASE_ERROR"
+    assert "テスト用のデータベースエラー" in error_response["error"]["message"]
+
+def test_update_device_success(test_db):
+    """デバイス更新の正常系テスト"""
+    # テスト用デバイスの作成
+    test_device = Device(
+        id="12345678-1234-5678-1234-567812345678",
+        name="テスト機器",
+        manufacturer="テストメーカー"
+    )
+    
+    # テストデータの保存
+    with test_db.connect() as connection:
+        connection.execute(Device.__table__.insert().values(
+            id=test_device.id,
+            name=test_device.name,
+            manufacturer=test_device.manufacturer,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC)
+        ))
+        connection.commit()
+    
+    # 更新データ
+    update_data = {
+        "name": "更新後の機器名",
+        "manufacturer": "更新後のメーカー"
+    }
+    
+    # 更新リクエスト
+    response = client.put(f"/api/v1/devices/{test_device.id}", json=update_data)
+    assert response.status_code == 200
+    
+    # レスポンスの検証
+    updated_device = response.json()
+    assert updated_device["name"] == update_data["name"]
+    assert updated_device["manufacturer"] == update_data["manufacturer"]
+    assert updated_device["id"] == test_device.id
+    assert "created_at" in updated_device
+    assert "updated_at" in updated_device
+
+def test_update_device_invalid_id(test_db):
+    """不正なIDフォーマットでの更新テスト"""
+    invalid_id = "invalid-123"
+    update_data = {
+        "name": "更新後の機器名",
+        "manufacturer": "更新後のメーカー"
+    }
+    
+    response = client.put(f"/api/v1/devices/{invalid_id}", json=update_data)
+    assert response.status_code == 400
+    
+    error_response = response.json()
+    assert "error" in error_response
+    assert error_response["error"]["code"] == "VALIDATION_ERROR"
+    assert "無効なデバイスID" in error_response["error"]["message"]
+    assert error_response["error"]["details"]["device_id"] == invalid_id
+
+def test_update_device_not_found(test_db):
+    """存在しないデバイスの更新テスト"""
+    non_existent_id = "00000000-0000-0000-0000-000000000000"
+    update_data = {
+        "name": "更新後の機器名",
+        "manufacturer": "更新後のメーカー"
+    }
+    
+    response = client.put(f"/api/v1/devices/{non_existent_id}", json=update_data)
+    assert response.status_code == 404
+    
+    error_response = response.json()
+    assert "error" in error_response
+    assert error_response["error"]["code"] == "DEVICE_NOT_FOUND"
+    assert non_existent_id in error_response["error"]["message"]
+
+def test_update_device_validation_error(test_db):
+    """バリデーションエラーのテスト"""
+    test_device_id = "12345678-1234-5678-1234-567812345678"
+    
+    # 名前が空の場合
+    response = client.put(f"/api/v1/devices/{test_device_id}", json={
+        "name": "",
+        "manufacturer": "テストメーカー"
+    })
+    assert response.status_code == 400
+    assert "デバイス名は必須です" in response.json()["error"]["message"]
+    
+    # メーカー名が空の場合
+    response = client.put(f"/api/v1/devices/{test_device_id}", json={
+        "name": "テストデバイス",
+        "manufacturer": ""
+    })
+    assert response.status_code == 400
+    assert "メーカー名は必須です" in response.json()["error"]["message"]
+
+def test_update_device_database_error(test_db):
+    """データベースエラーのテスト"""
+    error_trigger_id = "11111111-1111-1111-1111-111111111111"
+    update_data = {
+        "name": "更新後の機器名",
+        "manufacturer": "更新後のメーカー"
+    }
+    
+    response = client.put(f"/api/v1/devices/{error_trigger_id}", json=update_data)
+    assert response.status_code == 500
+    
+    error_response = response.json()
+    assert "error" in error_response
+    assert error_response["error"]["code"] == "DATABASE_ERROR"
+    assert "テスト用のデータベースエラー" in error_response["error"]["message"]
+
+def test_update_device_422_validation_error(test_db):
+    """FastAPIのバリデーションエラー（422）のテスト"""
+    test_device_id = "a51844dd-f16e-41c3-862c-0b13ce8455a5"
+    
+    # ケース1: リクエストボディが空の場合
+    response = client.put(
+        f"/api/v1/devices/{test_device_id}",
+        json=None
+    )
+    assert response.status_code == 422
+    error_detail = response.json()["detail"]
+    assert isinstance(error_detail, list)
+    assert error_detail[0]["loc"] == ["body"]
+    assert "field required" in error_detail[0]["msg"]
+    
+    # ケース2: 必須フィールドが欠けている場合
+    response = client.put(
+        f"/api/v1/devices/{test_device_id}",
+        json={"name": "テストデバイス"}  # manufacturerが欠けている
+    )
+    assert response.status_code == 422
+    error_detail = response.json()["detail"]
+    assert isinstance(error_detail, list)
+    assert error_detail[0]["loc"] == ["body", "manufacturer"]
+    assert "field required" in error_detail[0]["msg"]
+    
+    # ケース3: 不正な型の値が含まれる場合
+    response = client.put(
+        f"/api/v1/devices/{test_device_id}",
+        json={
+            "name": 123,  # 文字列ではなく数値
+            "manufacturer": "テストメーカー"
+        }
+    )
+    assert response.status_code == 422
+    error_detail = response.json()["detail"]
+    assert isinstance(error_detail, list)
+    assert error_detail[0]["loc"] == ["body", "name"]
+    assert "str type expected" in error_detail[0]["msg"]
+    
+    # ケース4: 不正なJSON形式
+    response = client.put(
+        f"/api/v1/devices/{test_device_id}",
+        headers={"Content-Type": "application/json"},
+        content="invalid json data"
+    )
+    assert response.status_code == 422
+    error_detail = response.json()["detail"]
+    assert isinstance(error_detail, list)
+    assert "JSON decode error" in error_detail[0]["msg"] 


### PR DESCRIPTION
## issue
- closes  #29 

# PUT /devices/{id} API テスト手順書

## 1. 事前準備（テスト用デバイスの作成）

### 1.1 POSTでテスト用デバイスを作成
**エンドポイント**: POST `/api/v1/devices`

```json
// リクエストボディ
{
  "name": "テストデバイス",
  "manufacturer": "テストメーカー"
}
```

**レスポンス（201 Created）**:
```json
{
  "id": "a51844dd-f16e-41c3-862c-0b13ce8455a5",  // このIDを保存
  "name": "テストデバイス",
  "manufacturer": "テストメーカー",
  "created_at": "2024-02-22T12:02:29",
  "updated_at": "2024-02-22T12:02:29"
}
```

## 2. 正常系テスト

### 2.1 デバイス情報の更新
**エンドポイント**: PUT `/api/v1/devices/a51844dd-f16e-41c3-862c-0b13ce8455a5`

```json
// リクエストボディ
{
  "name": "更新後のデバイス",
  "manufacturer": "更新後のメーカー"
}
```

**確認項目**:
1. ステータスコード: 200
2. レスポンスボディ:
```json
{
  "id": "a51844dd-f16e-41c3-862c-0b13ce8455a5",
  "name": "更新後のデバイス",
  "manufacturer": "更新後のメーカー",
  "created_at": "2024-02-22T12:02:29",
  "updated_at": "2024-02-22T12:03:45"  // 更新時刻が変更
}
```

## 3. エラーケーステスト

### 3.1 無効なUUID形式（400 Bad Request）
**エンドポイント**: PUT `/api/v1/devices/invalid-123`

```json
// リクエストボディ
{
  "name": "テストデバイス",
  "manufacturer": "テストメーカー"
}
```

**確認項目**:
1. ステータスコード: 400
2. レスポンスボディ:
```json
{
  "error": {
    "code": "VALIDATION_ERROR",
    "message": "無効なデバイスID: invalid-123",
    "details": {
      "device_id": "invalid-123"
    }
  }
}
```

### 3.2 存在しないデバイスID（404 Not Found）
**エンドポイント**: PUT `/api/v1/devices/00000000-0000-0000-0000-000000000000`

```json
// リクエストボディ
{
  "name": "テストデバイス",
  "manufacturer": "テストメーカー"
}
```

**確認項目**:
1. ステータスコード: 404
2. レスポンスボディ:
```json
{
  "error": {
    "code": "DEVICE_NOT_FOUND",
    "message": "デバイスが見つかりません: 00000000-0000-0000-0000-000000000000",
    "details": {
      "device_id": "00000000-0000-0000-0000-000000000000"
    }
  }
}
```

### 3.3 リクエストボディが空（422 Unprocessable Entity）
**エンドポイント**: PUT `/api/v1/devices/a51844dd-f16e-41c3-862c-0b13ce8455a5`

```json
// リクエストボディ
// 空のボディを送信
```

**確認項目**:
1. ステータスコード: 422
2. レスポンスボディ:
```json
{
  "detail": [
    {
      "type": "json_invalid",
      "loc": ["body", 0],
      "msg": "JSON decode error",
      "input": {},
      "ctx": {
        "error": "Expecting value"
      }
    }
  ]
}
```

### 3.4 必須フィールドの欠落（422 Unprocessable Entity）
**エンドポイント**: PUT `/api/v1/devices/a51844dd-f16e-41c3-862c-0b13ce8455a5`

```json
// リクエストボディ
{
  "name": "テストデバイス"
  // manufacturerフィールドが欠落
}
```

**確認項目**:
1. ステータスコード: 422
2. レスポンスボディ:
```json
{
  "detail": [
    {
      "loc": ["body", "manufacturer"],
      "msg": "field required",
      "type": "value_error.missing"
    }
  ]
}
```

### 3.5 不正な型の値（422 Unprocessable Entity）
**エンドポイント**: PUT `/api/v1/devices/a51844dd-f16e-41c3-862c-0b13ce8455a5`

```json
// リクエストボディ
{
  "name": 123,  // 文字列ではなく数値
  "manufacturer": "テストメーカー"
}
```

**確認項目**:
1. ステータスコード: 422
2. レスポンスボディ:
```json
{
  "detail": [
    {
      "type": "string_type",
      "loc": ["body", "name"],
      "msg": "Input should be a valid string",
      "input": 123
    }
  ]
}
```

### 3.6 データベースエラー（500 Internal Server Error）
**エンドポイント**: PUT `/api/v1/devices/11111111-1111-1111-1111-111111111111`

```json
// リクエストボディ
{
  "name": "テストデバイス",
  "manufacturer": "テストメーカー"
}
```

**確認項目**:
1. ステータスコード: 500
2. レスポンスボディ:
```json
{
  "error": {
    "code": "DATABASE_ERROR",
    "message": "テスト用のデータベースエラー",
    "details": {}
  }
}
```

## 4. テスト実行時の注意事項

1. **ヘッダー設定**
   - Content-Type: application/json を必ず設定

2. **テスト順序**
   - 正常系テストを最初に実行
   - その後、各エラーケースをテスト
   - データベースエラーテストは最後に実行

3. **レスポンス確認項目**
   - ステータスコード
   - エラーコード
   - メッセージ内容
   - 詳細情報（details）の存在
   - タイムスタンプのフォーマット（正常系の場合）

4. **クリーンアップ**
   - テスト完了後、作成したテストデータを削除
   ```
   DELETE /api/v1/devices/a51844dd-f16e-41c3-862c-0b13ce8455a5
   ```

はい、APIテスト手順書の最後に`loc`配列の説明を追加いたします。

## 5. エラーレスポンスの`loc`配列について

### 5.1 `loc`配列の基本構造
`loc`配列は、エラーが発生した正確な位置を示す情報を提供します：
```json
"loc": ["場所", "位置やフィールド名"]
```

### 5.2 主なパターンと意味

1. **リクエストボディのJSONパースエラー**
```json
"loc": ["body", 0]
```
- 第一引数`"body"`: エラーが発生した場所がリクエストボディであることを示す
- 第二引数`0`: JSONパースエラーが発生した位置（インデックス0は先頭を意味する）
  - つまり、JSONデータの解析が開始位置で失敗したことを示す
  - 一般的に、リクエストボディが完全に空か、不正なJSON形式であることを意味する

2. **特定のフィールドのバリデーションエラー**
```json
"loc": ["body", "name"]
```
- 第一引数`"body"`: リクエストボディ内でのエラー
- 第二引数`"name"`: 具体的なフィールド名
  - この場合、`name`フィールドでバリデーションエラーが発生したことを示す

### 5.3 実例と解釈

1. **空のリクエストボディ**
```json
{
  "detail": [
    {
      "type": "json_invalid",
      "loc": ["body", 0],
      "msg": "JSON decode error",
      "input": {},
      "ctx": {
        "error": "Expecting value"
      }
    }
  ]
}
```
- 解釈：リクエストボディの解析が先頭（インデックス0）で失敗
- 原因：ボディが空か、JSONとして解析できないデータ

2. **必須フィールド欠落**
```json
{
  "detail": [
    {
      "loc": ["body", "manufacturer"],
      "msg": "field required",
      "type": "value_error.missing"
    }
  ]
}
```
- 解釈：リクエストボディ内の`manufacturer`フィールドでエラー
- 原因：必須フィールドが存在しない

### 5.4 注意点

- `loc`配列は常にエラーの「パス」を示す
- 最初の要素は常にエラーが発生した大まかな場所（`body`、`query`、`path`など）
- 2番目以降の要素で具体的な位置やフィールドを特定
- `0`のような数値は通常、JSONパースエラーの位置を示す
- フィールド名の場合は、具体的なフィールドでのバリデーションエラーを示す
