### PR TITLE
#31/ DynamoDB 対応 4.12 DynamoDB テーブル作成

### DIFF
--- a/backend/lambda/devices/scripts/insert_test_data.py
+++ b/backend/lambda/devices/scripts/insert_test_data.py
@@ -16,45 +16,48 @@ logger = logging.getLogger(__name__)
 # 環境変数の読み込み
 load_dotenv()
 
-# テスト用の環境変数を一時的に設定
-os.environ['RDS_HOST'] = 'localhost'
-os.environ['RDS_PORT'] = '3306'
-os.environ['RDS_USER'] = 'root'
-os.environ['RDS_PASSWORD'] = 'okitasouji'
-os.environ['RDS_DATABASE'] = 'lambdadb'
+# DynamoDB用の環境変数を設定
+os.environ['DB_TYPE'] = 'dynamodb'
+os.environ['DYNAMODB_TABLE_NAME'] = 'devices'
 
 def generate_test_data():
     """テストデータを生成する"""
+    current_time = datetime.now().isoformat()
     return [
         {
             'id': str(uuid.uuid4()),
             'name': 'エアコン',
             'manufacturer': 'パナソニック',
-            'created_at': datetime.now().isoformat()
+            'created_at': current_time,
+            'updated_at': current_time
         },
         {
             'id': str(uuid.uuid4()),
             'name': '冷蔵庫',
             'manufacturer': '日立',
-            'created_at': datetime.now().isoformat()
+            'created_at': current_time,
+            'updated_at': current_time
         },
         {
             'id': str(uuid.uuid4()),
             'name': '洗濯機',
             'manufacturer': 'シャープ',
-            'created_at': datetime.now().isoformat()
+            'created_at': current_time,
+            'updated_at': current_time
         },
         {
             'id': str(uuid.uuid4()),
             'name': '電子レンジ',
             'manufacturer': '東芝',
-            'created_at': datetime.now().isoformat()
+            'created_at': current_time,
+            'updated_at': current_time
         },
         {
             'id': str(uuid.uuid4()),
             'name': '掃除機',
             'manufacturer': 'ダイソン',
-            'created_at': datetime.now().isoformat()
+            'created_at': current_time,
+            'updated_at': current_time
         }
     ]
 
@@ -63,7 +66,7 @@ def insert_test_data():
     try:
         # データベースインターフェースの取得
         db = get_db_interface()
-        logger.info(f"データベースに接続しました（タイプ: {os.getenv('DB_TYPE', 'rds')}）")
+        logger.info(f"データベースに接続しました（タイプ: {os.getenv('DB_TYPE', 'dynamodb')}）")
 
         # 既存のデータを確認
         existing_devices = db.list_devices()


### PR DESCRIPTION
## issue
- closes  #31 

# DynamoDB 対応 4.12 DynamoDB テーブル作成

## 📝 概要
機器管理システムのデータベースをDynamoDBで実装し、MySQLと同等の機能を実現しました。

## 🏗️ テーブル設計

### テーブル名: `devices`

#### 属性定義
| 属性名 | 型 | 説明 | 備考 |
|--------|-----|------|------|
| id | String | デバイスの一意識別子 | パーティションキー |
| name | String | 機器名 | - |
| manufacturer | String | メーカー名 | - |
| created_at | String | 作成日時 | ISO8601形式 |
| updated_at | String | 更新日時 | ISO8601形式 |

#### プロビジョニング設定
- 読み込みキャパシティーユニット: 5
- 書き込みキャパシティーユニット: 5

## 💻 実装詳細

### 1. データベースインターフェース
```python
class DynamoDBInterface(DatabaseInterface):
    def __init__(self):
        self.dynamodb = boto3.resource('dynamodb')
        self.table = self.dynamodb.Table('devices')

    def create_device(self, device_data: Dict) -> Dict
    def get_device(self, device_id: str) -> Optional[Dict]
    def update_device(self, device_id: str, update_data: Dict) -> Optional[Dict]
    def delete_device(self, device_id: str) -> bool
    def list_devices(self) -> List[Dict]
```

### 2. 環境変数設定
```env
DB_TYPE=dynamodb
DYNAMODB_TABLE_NAME=devices
AWS_REGION=ap-northeast-1
AWS_ACCESS_KEY_ID=<アクセスキー>
AWS_SECRET_ACCESS_KEY=<シークレットキー>
```

### 3. テストデータ
```json
{
    "id": "UUID文字列",
    "name": "機器名",
    "manufacturer": "メーカー名",
    "created_at": "2024-02-22T15:12:54.142713",
    "updated_at": "2024-02-22T15:12:54.142713"
}
```

## 🔄 MySQLとの比較

### 共通点
- 同一のインターフェースを実装
- CRUD操作の完全サポート
- タイムスタンプの管理
- 一意のID（UUID）による識別

### 相違点
| 機能 | MySQL | DynamoDB |
|------|--------|----------|
| スキーマ | 固定 | 柔軟 |
| トランザクション | ACID準拠 | 単一テーブル操作が基本 |
| インデックス | B-treeインデックス | GSI（グローバルセカンダリインデックス） |
| データ型 | 厳密な型チェック | 柔軟な型サポート |

## 🔄 切り替え方法
環境変数 `DB_TYPE` の値を変更することで、データベースを切り替え可能：
- MySQL: `DB_TYPE=rds`
- DynamoDB: `DB_TYPE=dynamodb`

## 📝 注意事項
1. DynamoDBはスキーマレスですが、アプリケーション側で属性の整合性を維持
2. タイムスタンプはISO8601形式の文字列として保存
3. UUIDは文字列として保存
4. エラーハンドリングはMySQLと同様のパターンを踏襲